### PR TITLE
Add jQuery to package to resolve error

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gulp-util": "^3.0.0",
     "highlight.js": "^8.1.0",
     "jest-cli": "^0.1.17",
+    "jquery": "^1.10.0",
     "react": "^0.11.1",
     "react-hot-loader": "^0.2.0",
     "react-router": "^0.5.0",


### PR DESCRIPTION
If you clone coffee-quick-react as it stands now, run `npm install` and then `cult watch`, you get an error because backbone thinks it requires jQuery. this was the simple fix.
