### PR TITLE
Explicit render target to prevent issues with react-router

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Open+Sans:400/Lato:700">
   </head>
   <body>
+    <div id="app"></div>
     <script src="/bundle.js"></script>
   </body>
 </html>

--- a/src/scripts/router.cjsx
+++ b/src/scripts/router.cjsx
@@ -21,5 +21,5 @@ routes = (
   </Route>
 )
 Router.run(routes, (Handler) ->
-  React.render <Handler/>, document.body
+  React.render <Handler/>, document.getElementById 'app'
 )


### PR DESCRIPTION
Awesome work on this! I ran into a nasty bug last night with react-router, so in the interest of saving others the trouble...

When changing routes via `.transitionTo()`, react-router will (on certain machines, seems to be a race condition) render multiple `<Router>`s into the body. This causes a slew of `ReactMount` errors.

The fix (suggested by OP) was to render to an explicit target, as opposed to `<body>`.

Issue thread: [react-router/issues/600](react-router/issues/600)